### PR TITLE
Upgrade RabbitMQ to 3.3.5

### DIFF
--- a/files/brews/rabbitmq.rb
+++ b/files/brews/rabbitmq.rb
@@ -2,10 +2,10 @@ require 'formula'
 
 class Rabbitmq < Formula
   homepage 'http://rabbitmq.org/'
-  url 'http://www.rabbitmq.com/releases/rabbitmq-server/v3.2.1/rabbitmq-server-mac-standalone-3.2.1.tar.gz'
-  sha1 '471da627e8ccb36a7bc6586fb1c43393224eac5d'
+  url 'http://www.rabbitmq.com/releases/rabbitmq-server/v3.3.5/rabbitmq-server-mac-standalone-3.3.5.tar.gz'
+  sha1 '3658add67d9ee7503bed8781c2073dca08460124'
 
-  version '3.2.1-boxen1'
+  version '3.3.5-boxen1'
 
   def install
     # Install the base files

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class rabbitmq {
   }
 
   package { 'boxen/brews/rabbitmq':
-    ensure => '3.2.1-boxen1',
+    ensure => '3.3.5-boxen1',
     notify => Service['dev.rabbitmq'],
   }
 

--- a/spec/classes/rabbitmq_spec.rb
+++ b/spec/classes/rabbitmq_spec.rb
@@ -35,7 +35,7 @@ end
 
     should contain_homebrew__formula('rabbitmq').with_before('Package[boxen/brews/rabbitmq]')
     should contain_package('boxen/brews/rabbitmq').with({
-      :ensure => '3.1.5-boxen1',
+      :ensure => '3.3.5-boxen1',
       :notify => 'Service[dev.rabbitmq]'
     })
 


### PR DESCRIPTION
This upgrade works locally on my boxen setup but I couldn't get a clean build of the test suite. I've tried to upgrade `cardboard` to the latest 2.1.x release to run the build against Ruby 2 but without any success. Let me know if there is anything else I need to change to get it 100%.
